### PR TITLE
(isssue#2) Change: Append nav to #wrapper parent instead of body

### DIFF
--- a/js/contentsView.js
+++ b/js/contentsView.js
@@ -160,7 +160,7 @@ define(function(require) {
         plpTemplate = Handlebars.templates.contents;
       }
       var context = this;
-      $('html').find('body').append(this.$el.html(plpTemplate({
+      $('html').find('#wrapper').parent().append(this.$el.html(plpTemplate({
         'settings': Adapt.course.get('_contents'),
         'page': this.model.pages,
         '_globals': this.model._globals


### PR DESCRIPTION
- [See: Issue#2](https://github.com/KingsOnline/adapt-contents/issues/2)

Allow the content nav and page wrapper to be put into another wrapper for positioning that is not just body

instead of appending directly to body, find the adapt wrapper, climb up to it's parent and append the nav to the end of that parent

Should continue to work if the parent remains <body>